### PR TITLE
macos: add required libraries for FFI bindings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,8 +31,6 @@ fn main() {
         .status()
         .expect("make");
 
-    dbg!(cbqn_build);
-
     if !cbqn_build.success() {
         std::process::exit(1);
     }

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,11 @@ use std::{env, fs, path::PathBuf, process::Command};
 fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     let cbqn_dir = out_dir.join("CBQN");
+    let ld_libs = if cfg!(target_os = "macos") {
+        format!("LD_LIBS={}", "-lffi")
+    } else {
+        format!("")
+    };
 
     dir::remove(&cbqn_dir).unwrap();
 
@@ -21,9 +26,12 @@ fn main() {
     let cbqn_build = Command::new("make")
         .arg("shared-o3")
         .arg("libcbqn.so")
+        .arg(ld_libs)
         .current_dir(&cbqn_dir)
         .status()
         .expect("make");
+
+    dbg!(cbqn_build);
 
     if !cbqn_build.success() {
         std::process::exit(1);


### PR DESCRIPTION
Currently, `cbqn-sys` is blocking building of programs that depend on it, such as your LSP server on macOS. I tried to build your editor tools in Nix, but this package yields the following error on build:

```
  --- stderr
  ld: unknown option: --dynamic-list=include/syms
  clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
  make[2]: *** [makefile:191: obj/def_shared_o3/BQN] Error 1
  make[1]: *** [makefile:176: run_incremental_0] Error 2
  make: *** [makefile:37: shared-o3] Error 2
```

This PR fixes that problem (though with the assumption that `libffi` is installed). This same problem is documented on upstream, but there is no easy way to endorse the setting when the LSP server is building these packages as dependencies.